### PR TITLE
Block ff on production branches

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,9 @@ import { GitHubClientWrapper } from './github_client_wrapper';
 import { FastForwardAction } from './fast_forward_action';
 
 async function run(): Promise<void> {
+  const RESTRICTED_BRANCHES: string[] = ['master', 'main', 'uat'];
+  const NEEDS_RELEASE_APPROVAL_BRANCHES: string[] = ['master', 'main', 'uat', 'develop'];
+
   try {
     const github_token = core.getInput('GITHUB_TOKEN');
     const octokit = github.getOctokit(github_token);
@@ -44,7 +47,13 @@ async function run(): Promise<void> {
     });
 
     const base_branch = pull.data.base.ref;
-    const needs_release_approval = ['master', 'main', 'develop'].includes(base_branch);
+    const needs_release_approval = NEEDS_RELEASE_APPROVAL_BRANCHES.includes(base_branch);
+
+    if (RESTRICTED_BRANCHES.includes(base_branch) && pull.data.head.ref === base_branch) {
+      core.setFailed(`Fast-forward blocked on '${base_branch}' branch.`);
+      await fastForward.async_comment_on_pr(comment_messages, false, prod_branch, stage_branch, 'missing_approval');
+      return;
+    }
 
     if (needs_release_approval) {
       const approvers = await client.list_pull_request_approvers(pr_number);


### PR DESCRIPTION
This PR prevents fast-forward merges on production branches.

Strategy
- The master branch will now only be updated by the release committee.
- While this PR is not strictly required, it enforces restrictions on fast-forward merges for production branches.